### PR TITLE
add &subset=latin,latin-ext,cyrillic to Open Sans

### DIFF
--- a/combogen/templates/combo-chart-full.html
+++ b/combogen/templates/combo-chart-full.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{{ title }}</title>
-    <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' type='text/css'>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700&subset=latin,latin-ext,cyrillic' type='text/css'>
     <link rel="stylesheet" href="https://use.typekit.net/ucr7myw.css">
     <link rel="stylesheet" href="{{ cfg.rel_resources_path }}/css/font-awesome.min.css">
     <link rel="stylesheet" href="{{ cfg.rel_resources_path }}/css/style.css">


### PR DESCRIPTION
Some languages require characters with diacritical marks. Czech language is not rendered properly. Adding latin-ext subset should fix issue for e.g. Czech language and cyrillic for Russian, Ukrainian or Bulgarian language.

More problematic are the special fonts in https://use.typekit.net/ucr7myw.css that need to have latin-ext characters as well since they don't render well for diacritical chars.